### PR TITLE
chore(markdown): migrate rows to directives

### DIFF
--- a/markdown/articles/2021/01/07/history-of-doomsday.md
+++ b/markdown/articles/2021/01/07/history-of-doomsday.md
@@ -56,7 +56,13 @@ Dragons and other {B}{R} creatures. As time went on, and new cards from Urza's
 Legacy were printed, he actually already found a copy, and use for Doomsday in
 his ~~pile~~ deck which he used to deploy a very efficient combo:
 
-<row variant="pile">{{!Meditate|TMP}} {{!Palinchron|ULG}} {{!Mana Flare|LEB}} {{!Turnabout|USG}} {{!Stroke of Genius|USG}}</row>
+:::row{variant=pile}
+- Meditate | TMP
+- Palinchron | ULG
+- Mana Flare | LEB
+- Turnabout | USG
+- Stroke of Genius | USG
+:::
 
 For only {4}{U}{U}{U}{R} this would give you infinite mana to cast an
 exponentially large Stroke at your opponent. Pretty powerful magic.

--- a/markdown/articles/2021/03/21/everything-vintage-doomsday.md
+++ b/markdown/articles/2021/03/21/everything-vintage-doomsday.md
@@ -233,7 +233,15 @@ Our hand is:
 >    Good things: it can keep Street Wraith. Wraith is a vital card to beating
 >    Brain Freeze.
 
-<row variant="hand">{{!DD}} {{!SW}} {{!Pre}} {{!FoW}} {{!Underground Sea|LEB}} {{!Tasigur, the Golden Fang}} {{!DR}}</row>
+:::row{variant=hand}
+- DD
+- SW
+- Pre
+- FoW
+- Underground Sea | LEB
+- Tasigur, the Golden Fang
+- DR
+:::
 
 ## Part 4: Playing vs. BUG
 

--- a/markdown/articles/2021/07/27/ddft-brewing.md
+++ b/markdown/articles/2021/07/27/ddft-brewing.md
@@ -19,7 +19,11 @@ play Doomsday and Tendrils of Agony in the same 75.
 
 ## The Starting Point
 
-<row variant="centered">{{!DD}} {{!EoE}} {{!BW}}</row>
+:::row
+- DD
+- EoE
+- BW
+:::
 
 This is roughly what I and others would consider a typical DDFT list in the
 present day. It has undergone some changes since [my original Echo Doomsday


### PR DESCRIPTION
This MR is to migrate card rows within Markdown to using the directive syntax that is being implemented in #111. There are 3 existing types of rows that need migrating:

- The *centered* variant
- The *pile* variant
- The *hand* variant

I've initiated the branch with 3 examples for each type.