### PR TITLE
wiki(meandeck): add Esper Vial matchup

### DIFF
--- a/markdown/chapters/meandeck/matchups.md
+++ b/markdown/chapters/meandeck/matchups.md
@@ -4,15 +4,22 @@ title: Matchup Guides
 ---
 
 With this chapter we want to give you a brief overview over the most relevant
-matchups in the current meta. We try to keep everything short and easy to read.
+matchups in the *current* meta. We try to keep everything short and easy to
+read.
 
-To keep everything easy to read, we organized every matchup as follows:
+Every matchup is organized as follows:
 
 - **Game plan**: a short summary of the matchup
-- **Cards to keep in mind**: cards that are important for the matchups, divided
-  in maindeck and sideboard
-- **Gameplay**: a longer guide how to play the pre and post Doomsday parts of
+- **Cards to keep in mind**: cards that are important for the matchups
+- **Gameplay**: a longer text on how to play the pre and post Doomsday parts of
   the matchup
+
+For reference, the document assumes a standard *Meandeck* list and should stay
+generic enough that it applies to all colors.
+
+::decklist{path=meandeck.wub}
+::decklist{path=meandeck.ubr}
+::decklist{path=meandeck.ubg}
 
 ## Table of Contents
 
@@ -36,8 +43,14 @@ early is best.
 
 ## Bant Miracles
 
-Beating countermagic is not your only problem, their hatebears and answers to
-Oracle will be the main reason you lose games.
+Take your time. Their main clock consists of early striges and Uro which should
+give you plenty of time to sculpt a hand and resolve Doomsday. Incidentally,
+resolving a turn 1 Doomsday while they're unable to produce a clock fast enough
+lets you protect a slow pass-the-turn pile thanks to :card[Cavern of Souls] or
+countermagic in multiple. The idea is that by stacking your next 5 draws you're
+supposedly drawing *better* than they will.
+
+Beware the eventual maindeck :card[Endurance] and :card[Dress Down]!
 
 ::accordion[Cards to keep in mind]{path=matchups/miracles.cards}
 ::accordion[Gameplay]{path=matchups/miracles.gameplay}
@@ -46,12 +59,23 @@ Oracle will be the main reason you lose games.
 
 Slam early and build your pile around mana and card draw denial.
 
+In longer games, they'll have access to more lock pieces and winning becomes a
+real puzzle. Winning early allows you to ignore most of them as they become
+relevant much later in the game. For instance resolving Doomsday on turn 1
+planning a turn 2 win plays around instant-speed :card[Flickerwisp] and
+:card[Skyclave Apparition]. In this case, you are giving them only one turn to
+react leaving much less options for them. Suddenly, you only have to beat one
+of: :card[Wasteland], :card[Rishadan Port], :card[Thalia, Guardian of Thraben]
+or :card[Spirit of the Labyrinth] instead of everything at once.
+
 ::accordion[Cards to keep in mind]{path=matchups/death-and-taxes.cards}
 ::accordion[Gameplay]{path=matchups/death-and-taxes.gameplay}
 
 ## Maverick
 
-An early Doomsday gives you enough time to build safe piles.
+Similarly to the Death and Taxes matchup, an early Doomsday gives you enough
+time to build safe piles. Avoid burying yourself under lock pieces for no good
+reason.
 
 ::accordion[Cards to keep in mind]{path=matchups/maverick.cards}
 ::accordion[Gameplay]{path=matchups/maverick.gameplay}
@@ -130,7 +154,7 @@ Race them, but keep their opportunity to mill you out in mind.
 
 ## Madness
 
-Just race, don't rely on a turn 3 Doomsday.
+Just race, don't rely on a turn 3 Doomsday off your lands.
 
 ::accordion[Cards to keep in mind]{path=matchups/madness.cards}
 ::accordion[Gameplay]{path=matchups/madness.gameplay}

--- a/markdown/chapters/meandeck/matchups.md
+++ b/markdown/chapters/meandeck/matchups.md
@@ -134,3 +134,8 @@ Just race, don't rely on a turn 3 Doomsday.
 
 ::accordion[Cards to keep in mind]{path=matchups/madness.cards}
 ::accordion[Gameplay]{path=matchups/madness.gameplay}
+
+## Esper Vial
+
+::accordion[Cards to keep in mind]{path=matchups/esper-vial.cards}
+::accordion[Gameplay]{path=matchups/esper-vial.gameplay}

--- a/markdown/chapters/meandeck/matchups.md
+++ b/markdown/chapters/meandeck/matchups.md
@@ -161,5 +161,7 @@ Just race, don't rely on a turn 3 Doomsday off your lands.
 
 ## Esper Vial
 
+Meddling Mage is the matchup defining card.
+
 ::accordion[Cards to keep in mind]{path=matchups/esper-vial.cards}
 ::accordion[Gameplay]{path=matchups/esper-vial.gameplay}

--- a/markdown/partials/matchups/aluren.gameplay.md
+++ b/markdown/partials/matchups/aluren.gameplay.md
@@ -23,4 +23,5 @@ resources to go off anymore, but that is not always the case, especially since
 :card[Acererak the Archlich] joined the format. Should they still be able to go
 off and you have enough cyclers in hand to cycle to Thassa's Oracle, be careful
 when casting it off :card[Aluren]. It's better to cast it when their combo
-creature is still on the stack, else they can react and combo off in response.
+creature is still on the stack, else they can react and combo off again in
+response.

--- a/markdown/partials/matchups/aluren.gameplay.md
+++ b/markdown/partials/matchups/aluren.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Aluren is a pretty slow combo deck. These days white seems to be preferred over
 the {U}{B}{G} lists. To go off they need at least 4 mana, :card[Aluren] and a
@@ -13,7 +13,7 @@ least 2 Force effects from their side and try to keep an eye out for
 :card[Opposition Agent] and :card[Hullbreacher]. The white lists also have
 access to hatebears so bringing removal might be warranted.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Many lists play :card[Endurance], like most green decks in the current meta, so
 prepare to play around at least one copy.

--- a/markdown/partials/matchups/death-and-taxes.cards.md
+++ b/markdown/partials/matchups/death-and-taxes.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Thalia, Guardian of Thraben
@@ -10,7 +10,7 @@
 - Sanctum Prelate
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Deafening Silence

--- a/markdown/partials/matchups/death-and-taxes.gameplay.md
+++ b/markdown/partials/matchups/death-and-taxes.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Against Death and Taxes resolving an early Doomsday is the safest way to win.
 Mulliganing for a turn 1 or turn 2 Doomsday is a good starting point.
@@ -13,7 +13,7 @@ In post board games play around :card[Mindbreak Trap] when it's reasonable and
 keep countermagic ready to fight :card[Deafening Silence]. Beware the vial on 3
 which can either represent :card[Flickerwisp] or :card[Aven Mindcensor].
 
-**Post Doomsday**
+###### Post Doomsday
 
 It's very important to keep in mind, that your mana is your biggest weakness and
 that you can not rely on cyclers as tool to work through your pile.

--- a/markdown/partials/matchups/delver.ur.cards.md
+++ b/markdown/partials/matchups/delver.ur.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Ragavan, Nimble Pilferer
@@ -8,7 +8,7 @@
 - Force of Will
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Pyroblast

--- a/markdown/partials/matchups/delver.ur.gameplay.md
+++ b/markdown/partials/matchups/delver.ur.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Playing a longer game against a deck with strong pressure and heavy protection
 has always been really hard, but now with the snowballing nature of Ragavan it's
@@ -23,7 +23,7 @@ would pitch to it for wins without passing the turn post Doomsday. To fight this
 problem many Doomsday lists play :card[Pact of Negation], because it's less
 resource intensive and supports wins without passing the turn.
 
-**Post Doomsday**
+###### Post Doomsday
 
 The post Doomsday game against UR Delver is very tricky. You often have to take
 risks to resolve Oracle without giving the Delver player too much time to look

--- a/markdown/partials/matchups/depths.wg.cards.md
+++ b/markdown/partials/matchups/depths.wg.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Endurance
@@ -8,7 +8,7 @@
 - Elvish Reclaimer
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Deafening Silence

--- a/markdown/partials/matchups/depths.wg.gameplay.md
+++ b/markdown/partials/matchups/depths.wg.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 The matchup plays pretty similar to the Maverick matchup, but you have to focus
 more on speed. GW Depths can set up a pretty early Dark Depths Combo with its
@@ -12,7 +12,7 @@ bring in more mana denial like :card[Collector Ouphe] or :card[Choke] and some
 basic combo hate with :card[Deafening Silence]. Still, nothing a fast Doomsday
 can't beat.
 
-**Post Doomsday**
+###### Post Doomsday
 
 For your pile, evaluate their pressure and build accordingly, but try to play
 around :card[Endurance] if possible.

--- a/markdown/partials/matchups/elves.cards.md
+++ b/markdown/partials/matchups/elves.cards.md
@@ -10,6 +10,7 @@
 ###### Sideboard
 
 :::row{variant=centered}
+- Endurance
 - Collector Ouphe
 - Thoughtseize
 - Deafening Silence

--- a/markdown/partials/matchups/elves.cards.md
+++ b/markdown/partials/matchups/elves.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Allosaurus Shepherd
@@ -7,7 +7,7 @@
 - Natural Order
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Collector Ouphe

--- a/markdown/partials/matchups/elves.gameplay.md
+++ b/markdown/partials/matchups/elves.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Since :card[Allosaurus Shepherd] removed all interaction in this matchup, it's
 only about racing and countering a :card[Thoughtseize] or :card[Deafening
@@ -11,7 +11,7 @@ They can set up very fast kills, either with Allosaurus Shepherd's activated
 ability or with :card[Natural Order]. Be careful and try to finish the game as
 fast as possible.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Pass the turn piles can be a tad risky due to their explosiveness. Especially
 turn 3 or later. Try to build fast piles.

--- a/markdown/partials/matchups/esper-vial.cards.md
+++ b/markdown/partials/matchups/esper-vial.cards.md
@@ -7,6 +7,7 @@
 - Aether Vial
 - Force of Will
 - Teferi, Time Raveler
+- Venser, Shaper Savant
 :::
 
 ###### Sideboard

--- a/markdown/partials/matchups/esper-vial.cards.md
+++ b/markdown/partials/matchups/esper-vial.cards.md
@@ -1,8 +1,10 @@
 ###### Maindeck
 
 :::row{variant=centered}
-- Endurance
-- Thoughtseize
+- Wasteland
+- Spirit of the Labyrinth
+- Meddling Mage
+- Aether Vial
 - Force of Will
 - Teferi, Time Raveler
 :::
@@ -10,10 +12,6 @@
 ###### Sideboard
 
 :::row{variant=centered}
-- Leovold, Emissary of Trest
+- Ethersworn Canonist
 - Force of Negation
-- Opposition Agent
-- Hullbreacher
-- Meddling Mage
-- Veil of Summer
 :::

--- a/markdown/partials/matchups/esper-vial.gameplay.md
+++ b/markdown/partials/matchups/esper-vial.gameplay.md
@@ -1,33 +1,34 @@
 ###### Pre Doomsday
 
 Overall Esper Vial is not a very fast deck. It needs some time to set up
-pressure. Most of its cards try to accumulate value and overwhelm you in the 
-long run. In Game 1 Esper Vial shoudln't be a huge problem. Yes, it plays
-Force of Will and Teferi, Time Raveler, but if you can put Doomsday on the
-stack before turn 3 you should have no problem resolving it. One counterspell
-from you is enopugh to push through most of the time. Daze is especially good
-in the matchup, because they have to use their mana in their early turns to
-play to the board, similar to DnT.
+pressure. Most of its cards try to accumulate value and overwhelm you in the
+long run. In game 1 Esper Vial shoudln't be a huge problem. Yes, it plays
+:card[Force of Will] and :card[Teferi, Time Raveler], but if you can put
+Doomsday on the stack before turn 3 you should have no problem resolving it. One
+counterspell is enough to push through most of the time. Daze is especially good
+in the matchup because they have to use their mana in their early turns to play
+to the board, similarly to Death and Taxes.
+
 Due to its *toolbox* nature, you can expect various threats from your opponent
 but mostly in the form of hatebears. Cards like :card[Meddling Mage] will slow
 you down by naming Doomsday itself.
-Post board many Esper Vial lists board in 4 Force of Negations. They are still
-not a control deck, but now we need resources to beat atleast 2 Forces.
-As a general advice, their mana can be very shaky, so preventing them from
-setting up a Aether Vial doesn't just saves you from uncounterable Meddling Mages
-but can also disrupt their whole gameplan. No Vial also forces them to play out
-Plains to enable their most important cards.
 
+Post-board many Esper Vial lists board in 4 :card[Force of Negation]. They are
+still not a control deck, but now we need resources to beat at least 2 Forces.
+As a general advice, their mana can be very shaky, so preventing them from
+setting up an Aether Vial doesn't just save you from uncounterable Meddling
+Mages but can also disrupt their whole gameplan. No Vial also forces them to
+play out Plains to enable their most important cards.
 
 ###### Post Doomsday
 
 Your gameplan after resolving Doomsday is very dependent on pressure and their
-possibilities to set up hatebears. If they have no pressure you can build a
-very slow pile and keep your removal and counterspells ready for the
-important threats and hatebears. In games where the pressure is already high
-when you resolve Doomsday, you either have to heavily rely on mass removal
-like Massacre, or build a really fast pile and take some risks.
+possibilities to set up hatebears. If they have no pressure you can build a very
+slow pile and keep your removal and counterspells ready for the important
+threats and hatebears. In games where the pressure is already high when you
+resolve Doomsday, you either have to heavily rely on mass removal like
+:card[Massacre], or build a really fast pile and take some risks.
 
-A small but important hint: When your opponent keeps up 4 Mana or has a vial
-on for be wary of Venser, Shaper Savant. It can bounce your Thassas Oracle
-on the stack even when it's casted with Cavern of Souls.
+A small but important hint: when your opponent keeps up 4 Mana or has a vial on
+4 be wary of :card[Venser, Shaper Savant]. It can bounce your oracle from the
+stack even when it's cast with Cavern of Souls.

--- a/markdown/partials/matchups/esper-vial.gameplay.md
+++ b/markdown/partials/matchups/esper-vial.gameplay.md
@@ -1,25 +1,33 @@
 ###### Pre Doomsday
 
+Overall Esper Vial is not a very fast deck. It needs some time to set up
+pressure. Most of its cards try to accumulate value and overwhelm you in the 
+long run. In Game 1 Esper Vial shoudln't be a huge problem. Yes, it plays
+Force of Will and Teferi, Time Raveler, but if you can put Doomsday on the
+stack before turn 3 you should have no problem resolving it. One counterspell
+from you is enopugh to push through most of the time. Daze is especially good
+in the matchup, because they have to use their mana in their early turns to
+play to the board, similar to DnT.
 Due to its *toolbox* nature, you can expect various threats from your opponent
 but mostly in the form of hatebears. Cards like :card[Meddling Mage] will slow
-you down by naming Doomsday itself. If your hand cannot beat a turn 2 Meddling
-Mage off :card[Cavern of Souls] or turn 3 off :card[Aether Vial], consider
-mulliganing more aggressively or countering the Vial.
+you down by naming Doomsday itself.
+Post board many Esper Vial lists board in 4 Force of Negations. They are still
+not a control deck, but now we need resources to beat atleast 2 Forces.
+As a general advice, their mana can be very shaky, so preventing them from
+setting up a Aether Vial doesn't just saves you from uncounterable Meddling Mages
+but can also disrupt their whole gameplan. No Vial also forces them to play out
+Plains to enable their most important cards.
+
 
 ###### Post Doomsday
 
-Passing the turn multiple times can be risky due to their permanent-based
-maindeck *hate*. Even in sideboarded games, :card[Massacre] is not a guaranteed
-hit as they can often withhold their Plains and still deploy hatebears.
+Your gameplan after resolving Doomsday is very dependent on pressure and their
+possibilities to set up hatebears. If they have no pressure you can build a
+very slow pile and keep your removal and counterspells ready for the
+important threats and hatebears. In games where the pressure is already high
+when you resolve Doomsday, you either have to heavily rely on mass removal
+like Massacre, or build a really fast pile and take some risks.
 
-They also have multiple ways to reduce your devotion to {U} at instant speed so
-watch out for active Vials and :card[Solitude]. Non-exhaustive list of relevant
-creatures they can *flash* in:
-
-- Off Vial on 2: :card[Gilded Drake] and :card[Ethersworn Canonist].
-  :card[Meddling Mage] naming Oracle in response to your draw effect can be
-  back-breaking
-- Off Vial on 3: :card[Flickerwisp], :card[Skyclave Apparition], :card[Spell
-  Queller]. :card[Recruiter of the Guard] can represent a new threat if they
-  have a second Vial or simply :card[Solitude]
-- Off Vial on 4: :card[Palace Jailer] and :card[Venser, Shaper Savant]
+A small but important hint: When your opponent keeps up 4 Mana or has a vial
+on for be wary of Venser, Shaper Savant. It can bounce your Thassas Oracle
+on the stack even when it's casted with Cavern of Souls.

--- a/markdown/partials/matchups/esper-vial.gameplay.md
+++ b/markdown/partials/matchups/esper-vial.gameplay.md
@@ -1,0 +1,25 @@
+###### Pre Doomsday
+
+Due to its *toolbox* nature, you can expect various threats from your opponent
+but mostly in the form of hatebears. Cards like :card[Meddling Mage] will slow
+you down by naming Doomsday itself. If your hand cannot beat a turn 2 Meddling
+Mage off :card[Cavern of Souls] or turn 3 off :card[Aether Vial], consider
+mulliganing more aggressively or countering the Vial.
+
+###### Post Doomsday
+
+Passing the turn multiple times can be risky due to their permanent-based
+maindeck *hate*. Even in sideboarded games, :card[Massacre] is not a guaranteed
+hit as they can often withhold their Plains and still deploy hatebears.
+
+They also have multiple ways to reduce your devotion to {U} at instant speed so
+watch out for active Vials and :card[Solitude]. Non-exhaustive list of relevant
+creatures they can *flash* in:
+
+- Off Vial on 2: :card[Gilded Drake] and :card[Ethersworn Canonist].
+  :card[Meddling Mage] naming Oracle in response to your draw effect can be
+  back-breaking
+- Off Vial on 3: :card[Flickerwisp], :card[Skyclave Apparition], :card[Spell
+  Queller]. :card[Recruiter of the Guard] can represent a new threat if they
+  have a second Vial or simply :card[Solitude]
+- Off Vial on 4: :card[Palace Jailer] and :card[Venser, Shaper Savant]

--- a/markdown/partials/matchups/hogaak.cards.md
+++ b/markdown/partials/matchups/hogaak.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Hedron Crab
@@ -8,7 +8,7 @@
 - Altar of Dementia
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Thoughtseize

--- a/markdown/partials/matchups/hogaak.gameplay.md
+++ b/markdown/partials/matchups/hogaak.gameplay.md
@@ -21,9 +21,15 @@ combo.
 ###### Post Doomsday
 
 Because Hogaak plays no cards to interact with you on the stack, resolving
-Doomsday is easy in itself. Playing around crab and fetchlands however can be
+Doomsday is easy in itself. Playing around crabs and fetchlands however can be
 very difficult, especially when passing the turn where they might have access to
-2 fetchland activations or worse, a second crab. If you have the resources, try
-building [Brainstorm piles](/meandeck/brainstorm/) as they can *fix* your pile
-after a crab trigger or Altar activation(s). Should you have to pass the turn,
-make sure you have answers at your disposal.
+2 fetchland activations or worse, a second crab.
+
+They can also attempt to shuffle your pile thanks to :card[Assassin's Trophy].
+It is a *may* clause but ponder whether you can part with a land during your
+turn.
+
+If you have the resources, try building [Brainstorm
+piles](/meandeck/brainstorm/) as they can *fix* your pile after a crab trigger
+or Altar activation(s). Should you have to pass the turn, make sure you have
+answers at your disposal.

--- a/markdown/partials/matchups/hogaak.gameplay.md
+++ b/markdown/partials/matchups/hogaak.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 The Hogaak matchup can be pretty tricky, because they have two ways to kill you,
 either with damage or with mill. They don't even have to completely mill your 60
@@ -18,7 +18,7 @@ Other than :card[Surgical Extraction], they don't play any sideboard hate for
 Doomsday. Countermagic is still paramount to keep them in check and protect your
 combo.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Because Hogaak plays no cards to interact with you on the stack, resolving
 Doomsday is easy in itself. Playing around crab and fetchlands however can be

--- a/markdown/partials/matchups/lands.cards.md
+++ b/markdown/partials/matchups/lands.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Ghost Quarter
@@ -9,7 +9,7 @@
 - Urza's Saga
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Pyroblast

--- a/markdown/partials/matchups/lands.gameplay.md
+++ b/markdown/partials/matchups/lands.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Lands has super strong mana denial, even more in game 2 and 3, and will probably
 always win the long game, it can also switch gears very fast thanks to
@@ -8,7 +8,7 @@ Based on that analysis, a fast Doomsday is the way to go. But when you are
 mulliganing, keep in mind how strong countermagic is against their post
 sideboard hate pieces.
 
-**Post Doomsday**
+###### Post Doomsday
 
 You have 3 main objectives post Doomsday:
 

--- a/markdown/partials/matchups/madness.cards.md
+++ b/markdown/partials/matchups/madness.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Anger
@@ -6,7 +6,7 @@
 - Burning Inquiry
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Mindbreak Trap

--- a/markdown/partials/matchups/madness.gameplay.md
+++ b/markdown/partials/matchups/madness.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Similar to Hogaak it's a race or die matchup, but Madness has zero interaction
 other than creature removal. They just slam and hope it's enough, and we do the
@@ -17,7 +17,7 @@ Should they have :card[Mindbreak Trap] in hand post sideboard, it's often pretty
 obvious, because it's very hard for them to keep interaction up while playing
 out their threats.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Their only ways to put hasty threats onto the board are :card[Vengevine] or
 :card[Anger] with a Mountain. This makes it very easy to predict their damage

--- a/markdown/partials/matchups/maverick.cards.md
+++ b/markdown/partials/matchups/maverick.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Gaddock Teeg
@@ -9,7 +9,7 @@
 - Dark Depths
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Deafening Silence

--- a/markdown/partials/matchups/maverick.gameplay.md
+++ b/markdown/partials/matchups/maverick.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 The matchup against Maverick plays pretty similar to the Death and Taxes
 matchup, with a small but important difference, :card[Green Sun's Zenith]. It
@@ -9,7 +9,7 @@ Some lists play :card[Dark Depths] as an alternative win condition, but it's not
 super common and the Dark Depths lines are all very telegraphed and easy to
 spot.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Like against most green decks :card[Endurance] is the only real threat to your
 easier and quick piles.

--- a/markdown/partials/matchups/miracles.cards.md
+++ b/markdown/partials/matchups/miracles.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Endurance
@@ -8,7 +8,7 @@
 - Teferi, Time Raveler
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Hullbreacher

--- a/markdown/partials/matchups/miracles.cards.md
+++ b/markdown/partials/matchups/miracles.cards.md
@@ -13,7 +13,7 @@
 :::row{variant=centered}
 - Hullbreacher
 - Ethersworn Canonist
-- Surgical Extraction
+- Court of Cunning
 - Force of Negation
 - Meddling Mage
 - Torpor Orb

--- a/markdown/partials/matchups/miracles.gameplay.md
+++ b/markdown/partials/matchups/miracles.gameplay.md
@@ -1,22 +1,22 @@
 ###### Pre Doomsday
 
-You can play a much slower game against Bant Miracles. They don't have any early
-threats and have to respect Daze. In game 1 one layer of protection is often
-enough to resolve a Doomday but in post board games it's advised to play more
-carefully.
+One layer of protection is usually enough to resolve a Doomday in game 1 but in
+post-board games it's advised to play more carefully.
 
 Many sideboarded games are defined by hatebears from their side, because they
-often don't have enough countermagic to just fight Doomsday on the stack. They
-have to try to lock us out of the game or rely on the pressure of their
-creatures.
+often don't have enough countermagic to fight Doomsday on the stack. They have
+to try to lock us out of the game or rely on the pressure of their creatures.
 
 ###### Post Doomsday
 
+Beating countermagic is not your only problem, their hatebears and answers to
+Oracle's trigger will be the main reason you lose games.
+
 After you resolved Doomsday everything is about beating :card[Endurance], and
-against some newer lists :card[Dress Down]. They are their main way to beat
-:card[Thassa's Oracle]. But there are many ways to play around these answers. In
-game 1 you have to rely on countermagic and discard, but in game 2 and 3 you'll
-often use a sideboard package, like :card[Emrakul, the Aeons Torn] +
-:card[Shelldock Isle]. These sideboard packages often come with their own
-weaknesses, like :card[Teferi, Time Raveler] or :card[Back to Basics], but are
-still better than just slamming 1 Oracle into a prepared opponent.
+against some newer lists :card[Dress Down]. They are their main ways to beat
+:card[Thassa's Oracle]'s trigger. But there are many ways to play around these
+answers. In game 1 you have to rely on countermagic and discard, but in game 2
+and 3 you'll often use a sideboard package, like :card[Emrakul, the Aeons
+Torn] + :card[Shelldock Isle]. These sideboard packages often come with their
+own weaknesses, like :card[Teferi, Time Raveler] or :card[Back to Basics], but
+are still better than just slamming 1 Oracle into a prepared opponent.

--- a/markdown/partials/matchups/miracles.gameplay.md
+++ b/markdown/partials/matchups/miracles.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 You can play a much slower game against Bant Miracles. They don't have any early
 threats and have to respect Daze. In game 1 one layer of protection is often
@@ -10,7 +10,7 @@ often don't have enough countermagic to just fight Doomsday on the stack. They
 have to try to lock us out of the game or rely on the pressure of their
 creatures.
 
-**Post Doomsday**
+###### Post Doomsday
 
 After you resolved Doomsday everything is about beating :card[Endurance], and
 against some newer lists :card[Dress Down]. They are their main way to beat

--- a/markdown/partials/matchups/post.cards.md
+++ b/markdown/partials/matchups/post.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Endurance
@@ -6,7 +6,7 @@
 - Pithing Needle
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Mindbreak Trap

--- a/markdown/partials/matchups/post.gameplay.md
+++ b/markdown/partials/matchups/post.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 This will be a short one. Just cast Doomsday as soon as possible and play around
 possible :card[Mindbreak Trap]s in sideboarded games.
@@ -6,7 +6,7 @@ possible :card[Mindbreak Trap]s in sideboarded games.
 Some lists play the :card[Dark Depths] combo. Like in any Dark Depths deck,
 their plays to create a 20/20 are very telegraphed.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Realistically speaking they only have one card to interact with you,
 :card[Endurance]. You should always have enough time for a pile that beats

--- a/markdown/partials/matchups/reanimator.cards.md
+++ b/markdown/partials/matchups/reanimator.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Grief
@@ -8,7 +8,7 @@
 - Unmask
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Iona, Shield of Emeria

--- a/markdown/partials/matchups/reanimator.gameplay.md
+++ b/markdown/partials/matchups/reanimator.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Do **not** keep hands without countermagic. You'll need it to protect your own
 combo and fighting off theirs. With all their discard effects one free counter
@@ -10,7 +10,7 @@ effects, without a good target their reanimation spells are mitigated. And as a
 little side note, most lists play only 8 slots dedicated to bin creatures into
 the graveyard and 12 reanimation spells.
 
-**Post Doomsday**
+###### Post Doomsday
 
 The scariest creatures they can reanimate post Doomsday are :card[Iona, Shield
 of Emeria] and :card[Ashen Rider], so try to be careful with your lands as they

--- a/markdown/partials/matchups/sagavan.cards.md
+++ b/markdown/partials/matchups/sagavan.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Ragavan, Nimble Pilferer
@@ -9,7 +9,7 @@
 - Urza's Saga
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Hullbreacher

--- a/markdown/partials/matchups/sagavan.gameplay.md
+++ b/markdown/partials/matchups/sagavan.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Jeskai Ragavan is still a somewhat unrefined archetype at the moment. There are
 many builds out there, from tempo style lists, over midrange variants, to more
@@ -8,7 +8,7 @@ The matches against this deck play pretty similar to the UR Delver matchup, but
 Jeskai Ragavan often has a weaker damage backup, because many lists play less or
 no :card[Lightning Bolt]s combined with less threats but more protection.
 
-**Post Doomsday**
+###### Post Doomsday
 
 The post Doomsday part of the game is often defined by the variant you play
 against or you think you play against. It's very important to try to identify

--- a/markdown/partials/matchups/show.ug.cards.md
+++ b/markdown/partials/matchups/show.ug.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Force of Will
@@ -7,7 +7,7 @@
 - Boseiju, Who Shelters All
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Surgical Extraction

--- a/markdown/partials/matchups/show.ug.gameplay.md
+++ b/markdown/partials/matchups/show.ug.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 OmniTell is a lot slower than its sister Sneak and Show, since it plays only
 :card[Show and Tell] and no Sneak Attack. It also plays only 4 counterspells
@@ -7,7 +7,7 @@ needed and we have time to set up, but a lost counter war over Doomsday, can
 have harsh consequences if they tutor :card[Surgical Extraction] from their
 sideboard with :card[Cunning Wish].
 
-**Post Doomsday**
+###### Post Doomsday
 
 You can build safe piles that either use their own Show and Tell to put Thassa's
 Oracle into play or just cast it off :card[Cavern of Souls] if you have access

--- a/markdown/partials/matchups/show.ur.cards.md
+++ b/markdown/partials/matchups/show.ur.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Daze
@@ -7,7 +7,7 @@
 - Boseiju, Who Shelters All
 :::
 
-**Sideboard**
+###### Sideboard
 
 :::row{variant=centered}
 - Ragavan, Nimble Pilferer

--- a/markdown/partials/matchups/show.ur.gameplay.md
+++ b/markdown/partials/matchups/show.ur.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 Sneak and Show is one of our harder combo matchups, but we should still be
 slightly favoured.
@@ -16,7 +16,7 @@ they will sculpt their hand better than you most of the time.
 In post board games they have two tricks up their sleeve, :card[Blood Moon]
 effects and Ragavan. Try to keep that in mind.
 
-**Post Doomsday**
+###### Post Doomsday
 
 If you have to pass the turn after resolving Doomsday, try to do so with
 available draw effects still in hand. This makes it risky for them to resolve

--- a/markdown/partials/matchups/show.ur.gameplay.md
+++ b/markdown/partials/matchups/show.ur.gameplay.md
@@ -8,7 +8,7 @@ important differences. We have better fast mana in the form of :card[Dark
 Ritual] and we only need one card to combo. This means we need less resources to
 combo and we can use cantrips to look for protection rather than combo cards.
 
-In games were you can't combo safe in turn 1 or 2 the game can evolve into a
+In games where you can't combo safe in turn 1 or 2 the game can evolve into a
 staredown while both players dig for interaction. Discard can be very helpful in
 situations like this. But be careful, if you play a list with less cantrips,
 they will sculpt their hand better than you most of the time.

--- a/markdown/partials/matchups/tes.cards.md
+++ b/markdown/partials/matchups/tes.cards.md
@@ -1,4 +1,4 @@
-**Maindeck**
+###### Maindeck
 
 :::row{variant=centered}
 - Orim's Chant
@@ -7,7 +7,7 @@
 - Echo of Eons
 :::
 
-**Sideboard**
+###### Sideboard
 
 TES doesn't have sideboard slots for us, the playset of :card[Burning Wish]es
 allows for a lot of flexibility, including different threats based on the board

--- a/markdown/partials/matchups/tes.gameplay.md
+++ b/markdown/partials/matchups/tes.gameplay.md
@@ -1,4 +1,4 @@
-**Pre Doomsday**
+###### Pre Doomsday
 
 The Epic Storm or TES for short is the slower combo deck in matchup. It plays no
 real interaction other than silence effects, which are mostly protection for
@@ -9,7 +9,7 @@ with Echo of Eons. Be carefull with your countermagic, try not to waste it. It's
 good to have a feeling for how far they are away from a kill, to assess the
 situation.
 
-**Post Doomsday**
+###### Post Doomsday
 
 Pass the turn piles are very risky against Storm decks, because the lifeloss of
 :card[Doomsday] puts them in the very good position of not needing a high Storm

--- a/src/components/Remark/constants.ts
+++ b/src/components/Remark/constants.ts
@@ -17,6 +17,7 @@ import {
 import { RemarkHeading } from '@/components/Remark/renderers/RemarkHeading';
 import { RemarkImage } from '@/components/Remark/renderers/RemarkImage';
 import { RemarkLink } from '@/components/Remark/renderers/RemarkLink';
+import { RemarkList } from '@/components/Remark/renderers/RemarkList';
 import {
   RemarkMana,
   Props as RemarkManaProps,
@@ -54,6 +55,7 @@ export const COMPONENTS: Components = {
   h5: RemarkHeading,
   h6: RemarkHeading,
   img: RemarkImage,
+  ol: RemarkList as Components['ol'],
   p: RemarkParagraph,
   table: RemarkTable,
   tbody: RemarkTableBody,
@@ -61,6 +63,7 @@ export const COMPONENTS: Components = {
   th: RemarkTableCell,
   thead: RemarkTableHead,
   tr: RemarkTableRow,
+  ul: RemarkList as Components['ul'],
 };
 
 export const COMPONENTS_EXTRA: {

--- a/src/components/Remark/renderers/RemarkList.tsx
+++ b/src/components/Remark/renderers/RemarkList.tsx
@@ -1,0 +1,17 @@
+import React, { ElementType, FunctionComponent, ReactNode } from 'react';
+import Typography from '@material-ui/core/Typography';
+
+// NOTE Typings for Components['ol'] and Components['ul']
+interface Props {
+  children: ReactNode & ReactNode[];
+  ordered: boolean;
+}
+
+export const RemarkList: FunctionComponent<Props> = ({ children, ordered }) => {
+  const component: ElementType = ordered ? 'ol' : 'ul';
+  return (
+    <Typography component={component} gutterBottom>
+      {children}
+    </Typography>
+  );
+};

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -86,8 +86,8 @@ const options: ThemeOptions = {
     h2: { fontSize: base.typography.pxToRem(48) },
     h3: { fontSize: base.typography.pxToRem(40) },
     h4: { fontSize: base.typography.pxToRem(32) },
-    h5: { fontSize: base.typography.pxToRem(24) },
-    h6: { fontSize: base.typography.pxToRem(20) },
+    h5: { fontSize: base.typography.pxToRem(26) },
+    h6: { fontSize: base.typography.pxToRem(22) },
   },
 };
 


### PR DESCRIPTION
Add a section for the Esper Vial matchup.

Opportunity PR to replace bold paragraphs with actual headings.