### PR TITLE
wiki(tempo): add first chapter

### DIFF
--- a/markdown/chapters/tempo/basics.md
+++ b/markdown/chapters/tempo/basics.md
@@ -1,0 +1,18 @@
+---
+order: 0
+title: The Basics
+---
+
+## Table of Contents
+
+## Preamble
+
+Lorem
+
+## One
+
+Lorem
+
+## Two
+
+Lorem

--- a/src/tools/markdown/constants/Category.ts
+++ b/src/tools/markdown/constants/Category.ts
@@ -3,4 +3,5 @@ export enum Category {
   DDEFT = 'ddeft',
   DDFT = 'ddft',
   MEANDECK = 'meandeck',
+  TEMPO = 'tempo',
 }

--- a/src/tools/markdown/constants/Menu.ts
+++ b/src/tools/markdown/constants/Menu.ts
@@ -1,4 +1,10 @@
-import { mdiEye, mdiFileDocumentMultiple, mdiFlash, mdiFlask } from '@mdi/js';
+import {
+  mdiEye,
+  mdiFileDocumentMultiple,
+  mdiFlash,
+  mdiFlask,
+  mdiSword,
+} from '@mdi/js';
 import { Category } from '@/tools/markdown/constants/Category';
 import type { MenuDecoration } from '@/tools/markdown/types';
 
@@ -24,6 +30,12 @@ export const DECORATIONS: MenuDecoration[] = [
     icon: mdiFlask,
     subtitle: 'Experimental Frenzy',
     title: 'DDEFT',
+  },
+  {
+    category: Category.TEMPO,
+    icon: mdiSword,
+    subtitle: 'Introducing the Combat Phase',
+    title: 'Tempo',
   },
   {
     category: Category.APPENDICES,


### PR DESCRIPTION
@Doishy As requested an initial draft for the upcoming *tempo* chapters.

A few notes on what you can change with the new entry

<img width="694" alt="image" src="https://user-images.githubusercontent.com/5608624/194778457-cc1f0d57-72c1-44c8-9449-de01a99bfdee.png">

- The title and subtitle can be changed [here](src/tools/markdown/constants/Menu.ts)
- The icon as well, here are the [available icons](https://materialdesignicons.com/)
- It would also need an introduction in the home page, like for the other 3 variants